### PR TITLE
Task is not complete until hipchat callback happens.

### DIFF
--- a/SendHipChatNotification.js
+++ b/SendHipChatNotification.js
@@ -36,8 +36,7 @@ exports.handler = (function(event, context) {
 		}
 
 		console.log(res);
-	});
-	
-	context.done(null, "Message Sent.");
 
+	  context.done(null, "Message Sent.");
+	});
 });


### PR DESCRIPTION
If you call context.done outside the callback, then Lambda will terminate before the message is actually sent.